### PR TITLE
Fix linking on MacOS

### DIFF
--- a/mpv.go
+++ b/mpv.go
@@ -5,6 +5,7 @@ package mpv
 #include <stdlib.h>
 #cgo linux pkg-config: mpv
 #cgo windows pkg-config: --static mpv
+#cgo darwin LDFLAGS: -lmpv
 
 char** makeCharArray(int size) {
     return calloc(sizeof(char*), size);


### PR DESCRIPTION
I added a CGO conditional so that only on MacOS `-lmpv` is added as linker flag. Windows/Linux behavior stays the same.

Otherwise we get this linker error when building a project depending on go-mpv:

```console
$ go build
# github.com/spezifisch/stmps
/usr/local/Cellar/go/1.21.3/libexec/pkg/tool/darwin_amd64/link: running cc failed: exit status 1
ld: warning: -no_pie is deprecated when targeting new OS versions
Undefined symbols for architecture x86_64:
  "_mpv_client_name", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_client_name in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_client_name)
  "_mpv_command", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_command in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_command_node_async, __cgo_22d87e31efea_Cfunc_mpv_command_async , __cgo_22d87e31efea_Cfunc_mpv_command_node , __cgo_22d87e31efea_Cfunc_mpv_command , __cgo_22d87e31efea_Cfunc_mpv_command_string )
  "_mpv_command_async", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_command_async in 000001.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_command_async)
  "_mpv_command_node", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_command_node in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_command_node_async, __cgo_22d87e31efea_Cfunc_mpv_command_node )
  "_mpv_command_node_async", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_command_node_async in 000001.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_command_node_async)
  "_mpv_command_string", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_command_string in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_command_string)
  "_mpv_create", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_create in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_create)
  "_mpv_error_string", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_error_string in 000002.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_error_string)
  "_mpv_event_name", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_event_name in 000003.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_event_name)
  "_mpv_free", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_free in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_free)
  "_mpv_get_property", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_get_property in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_get_property_string, __cgo_22d87e31efea_Cfunc_mpv_get_property , __cgo_22d87e31efea_Cfunc_mpv_get_property_osd_string , __cgo_22d87e31efea_Cfunc_mpv_get_property_async )
  "_mpv_get_property_async", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_get_property_async in 000001.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_get_property_async)
  "_mpv_get_property_osd_string", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_get_property_osd_string in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_get_property_osd_string)
  "_mpv_get_property_string", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_get_property_string in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_get_property_string)
  "_mpv_get_time_us", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_get_time_us in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_get_time_us)
  "_mpv_get_wakeup_pipe", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_get_wakeup_pipe in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_get_wakeup_pipe)
  "_mpv_initialize", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_initialize in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_initialize)
  "_mpv_load_config_file", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_load_config_file in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_load_config_file)
  "_mpv_observe_property", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_observe_property in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_observe_property)
  "_mpv_request_event", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_request_event in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_request_event)
  "_mpv_request_log_messages", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_request_log_messages in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_request_log_messages)
  "_mpv_set_option", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_set_option in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_set_option_string, __cgo_22d87e31efea_Cfunc_mpv_set_option )
  "_mpv_set_option_string", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_set_option_string in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_set_option_string)
  "_mpv_set_property", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_set_property in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_set_property, __cgo_22d87e31efea_Cfunc_mpv_set_property_string , __cgo_22d87e31efea_Cfunc_mpv_set_property_async )
  "_mpv_set_property_async", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_set_property_async in 000001.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_set_property_async)
  "_mpv_set_property_string", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_set_property_string in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_set_property_string)
  "_mpv_terminate_destroy", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_terminate_destroy in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_terminate_destroy)
  "_mpv_unobserve_property", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_unobserve_property in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_unobserve_property)
  "_mpv_wait_event", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_wait_event in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_wait_event)
  "_mpv_wakeup", referenced from:
      __cgo_22d87e31efea_Cfunc_mpv_wakeup in 000004.o
     (maybe you meant: __cgo_22d87e31efea_Cfunc_mpv_wakeup)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```